### PR TITLE
Set Host Names

### DIFF
--- a/jobs/dynatrace-oneagent-windows/spec
+++ b/jobs/dynatrace-oneagent-windows/spec
@@ -28,3 +28,6 @@ properties:
   dynatrace.applogaccess:
     description: 'Enable access to discovered application log files content'
     default: '1'
+  dynatrace.hostname:
+    description: 'Set the Hosts name reported by Dynatrace'
+    default: ''

--- a/jobs/dynatrace-oneagent-windows/templates/start.ps1
+++ b/jobs/dynatrace-oneagent-windows/templates/start.ps1
@@ -159,11 +159,6 @@ function setHostName()
 
         try {
             echo $cfgHostName | new-item -force -path "$configPath/hostname.conf" -type file
-
-            # Since the Installer-Script will already start the oneAgent service,
-            # we need to restart it, to apply the new settings.
-
-            restart-service "Dynatrace OneAgent" -ErrorAction Stop
         } catch {
             installLog "ERROR" "Setting Host-Name failed!"
             Exit 1
@@ -213,6 +208,9 @@ try {
 	Exit 1
 }
 
+#Set the Host-Name
+setHostName
+
 #run the installer
 try {
     $agentInstallerFile = $agentExpandPath + "/install.bat"
@@ -241,9 +239,6 @@ do {
 	$watchdogWaitCounter++
 } while ($output.length -eq 0)
 installLog "INFO" "Process $oneagentwatchdogProcessName has started"
-
-#Set the Host-Name
-setHostName
 
 #run this script infinitely and exit when drain-script was started
 installLog "INFO" "Waiting for drain.ps1 to stop start.ps1 script..."

--- a/jobs/dynatrace-oneagent-windows/templates/start.ps1
+++ b/jobs/dynatrace-oneagent-windows/templates/start.ps1
@@ -12,6 +12,7 @@ $cfgEnvironmentId = "<%= properties.dynatrace.environmentid %>"
 $cfgApiToken = "<%= properties.dynatrace.apitoken %>"
 $cfgApiUrl = "<%= properties.dynatrace.apiurl %>"
 $cfgSslMode = "<%= properties.dynatrace.sslmode %>"
+$cfgHostName = "<%= properties.dynatrace.hostname %>"
 
 $oneagentwatchdogProcessName = "oneagentwatchdog"
 $tempDir = "/var/vcap/data/dt_tmp"
@@ -21,6 +22,7 @@ $logDir = "/var/vcap/sys/log/dynatrace-oneagent-windows"
 $logFile = "$logDir/dynatrace-install.log"
 $dynatraceServiceName = "Dynatrace OneAgent"
 $exitHelperFile = "/var/vcap/jobs/dynatrace-oneagent-windows/exit"
+$configPath = "/ProgramData/dynatrace/oneagent/agent/config"
 
 # ==================================================
 # function section
@@ -150,6 +152,14 @@ function configureProxySettings() {
     }
 }
 
+function setHostName()
+{
+    if ($cfgHostName) {
+        installLog "INFO" "hostname settings found, setting Host-Name to $cfgHostName"
+        echo $cfgHostName | new-item -force -path "$configPath/hostname.conf" -type file
+    }
+}
+
 # ==================================================
 # main section
 # ==================================================
@@ -191,6 +201,9 @@ try {
 	installLog "ERROR" "Failed to extract $installerFile to $agentExpandPath"
 	Exit 1
 }
+
+#Set the Host-Name
+setHostName
 
 #run the installer
 try {

--- a/jobs/dynatrace-oneagent/spec
+++ b/jobs/dynatrace-oneagent/spec
@@ -30,3 +30,6 @@ properties:
   dynatrace.applogaccess:
     description: 'Enable access to discovered application log files content'
     default: '1'
+  dynatrace.hostname:
+    description: 'Set the Hosts name reported by Dynatrace'
+    default: ''

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -153,6 +153,16 @@ runInstaller() {
 setHostName() {
     <% if not p('dynatrace.hostname').blank? %>
         echo "<%= p('dynatrace.hostname') %>" > ${CONFIG_DIR}/hostname.conf
+
+        # Since the Installer-Script will already start the oneAgent process,
+        # we need to restart it, to apply the new settings.
+
+        if [[ -f "${ONEAGENT_INIT_FILE}" ]]; then
+            "${ONEAGENT_INIT_FILE}" restart
+        else
+            echo "ERROR: ${ONEAGENT_INIT_FILE} not found!"
+            exit 1
+        fi
     <% else %>
         #do nothing
         :
@@ -169,16 +179,6 @@ downloadAgent "$DOWNLOADURL" "$INSTALLER_FILE"
 runInstaller
 
 setHostName
-
-# Since the Installer-Script will already start the oneAgent process,
-# we need to restart it, to apply the new settings.
-
-if [[ -f "${ONEAGENT_INIT_FILE}" ]]; then
-    "${ONEAGENT_INIT_FILE}" restart
-else
-    echo "ERROR: ${ONEAGENT_INIT_FILE} not found!"
-    exit 1
-fi
 
 setWatchdogPid
 

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -150,19 +150,26 @@ runInstaller() {
     done
 }
 
+# Taken from Dynatrace Linux setup script
+createDirIfNotExistAndSetRights() {
+  local dir="${1}"
+  local rights="${2}"
+  if [ ! -d "${dir}" ]; then
+    if ! mkdir -p "${dir}"; then
+      installLog "Cannot create ${dir} directory."
+    fi
+  fi
+
+  if ! chmod "${rights}" "${dir}"; then
+    installLog "Cannot change permisions of ${dir} directory to ${rights}."
+  fi
+}
+
 setHostName() {
     <% if not p('dynatrace.hostname').blank? %>
+        installLog "INFO hostname settings found, setting Host-Name to <%= p('dynatrace.hostname') %>"
+        createDirIfNotExistAndSetRights ${CONFIG_DIR} 755
         echo "<%= p('dynatrace.hostname') %>" > ${CONFIG_DIR}/hostname.conf
-
-        # Since the Installer-Script will already start the oneAgent process,
-        # we need to restart it, to apply the new settings.
-
-        if [[ -f "${ONEAGENT_INIT_FILE}" ]]; then
-            "${ONEAGENT_INIT_FILE}" restart
-        else
-            echo "ERROR: ${ONEAGENT_INIT_FILE} not found!"
-            exit 1
-        fi
     <% else %>
         #do nothing
         :
@@ -176,9 +183,9 @@ fi
 INSTALLER_FILE="$TMPDIR/Dynatrace-OneAgent-Linux.sh"
 downloadAgent "$DOWNLOADURL" "$INSTALLER_FILE"
 
-runInstaller
-
 setHostName
+
+runInstaller
 
 setWatchdogPid
 

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -15,6 +15,8 @@ export TMPDIR="/var/vcap/data/dt_tmp"
 RUN_DIR="/var/vcap/sys/run/dynatrace-oneagent"
 LOG_DIR="/var/vcap/sys/log/dynatrace-oneagent"
 LOG_FILE="$LOG_DIR/dynatrace-install.log"
+CONFIG_DIR="/var/lib/dynatrace/oneagent/agent/config"
+ONEAGENT_INIT_FILE="/etc/init.d/oneagent"
 
 installLog() {
     echo "$1" | tee -a "${LOG_FILE}"
@@ -148,6 +150,15 @@ runInstaller() {
     done
 }
 
+setHostName() {
+    <% if not p('dynatrace.hostname').blank? %>
+        echo "<%= p('dynatrace.hostname') %>" > ${CONFIG_DIR}/hostname.conf
+    <% else %>
+        #do nothing
+        :
+    <% end %>
+}
+
 # Installation process starts here
 if [[ ! -d "${TMPDIR}" ]]; then
     mkdir -p "${TMPDIR}"
@@ -156,6 +167,18 @@ INSTALLER_FILE="$TMPDIR/Dynatrace-OneAgent-Linux.sh"
 downloadAgent "$DOWNLOADURL" "$INSTALLER_FILE"
 
 runInstaller
+
+setHostName
+
+# Since the Installer-Script will already start the oneAgent process,
+# we need to restart it, to apply the new settings.
+
+if [[ -f "${ONEAGENT_INIT_FILE}" ]]; then
+    "${ONEAGENT_INIT_FILE}" restart
+else
+    echo "ERROR: ${ONEAGENT_INIT_FILE} not found!"
+    exit 1
+fi
 
 setWatchdogPid
 


### PR DESCRIPTION
Dynatrace allows to set custom host names by adding a host name configuration file as mentioned in: 

https://www.dynatrace.com/support/help/infrastructure/hosts/how-do-i-set-custom-host-names-in-dynamic-environments/

In this PR we try to make this Feature available for the bosh-oneagent-release. 
