### PR TITLE
Allow to switch the monitoring mode between "Full-Stack" and “Cloud-Infrastructure"

### DIFF
--- a/jobs/dynatrace-oneagent/spec
+++ b/jobs/dynatrace-oneagent/spec
@@ -30,3 +30,6 @@ properties:
   dynatrace.applogaccess:
     description: 'Enable access to discovered application log files content'
     default: '1'
+  dynatrace.infraonly:
+    description: 'Enable Cloud-Infrastructure only monitoring (Disables Full-Stack monitoring)'
+    default: '0'

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -8,7 +8,7 @@ export ENV_ID="<%= p("dynatrace.environmentid") %>"
 export API_TOKEN="<%= p("dynatrace.apitoken") %>"
 export API_URL="<%= p("dynatrace.apiurl") %>"
 export SSL_MODE="<%= p("dynatrace.sslmode") %>"
-export APP_LOG_CONTENT_ACCESS="<%= p("dynatrace.applogaccess") %>"
+#export APP_LOG_CONTENT_ACCESS="<%= p("dynatrace.applogaccess") %>"
 
 export TMPDIR="/var/vcap/data/dt_tmp"
 
@@ -33,9 +33,33 @@ if [[ "$PROXY" != "" ]]; then
     export http_proxy="$PROXY"
 fi
 
-if [[ "$APP_LOG_CONTENT_ACCESS" != "" ]]; then
-    ARGS="$ARGS APP_LOG_CONTENT_ACCESS=$APP_LOG_CONTENT_ACCESS"
-fi
+#if [[ "$APP_LOG_CONTENT_ACCESS" != "" ]]; then
+#    ARGS="$ARGS APP_LOG_CONTENT_ACCESS=$APP_LOG_CONTENT_ACCESS"
+#fi
+
+<% if ['0','1'].include? p('dynatrace.applogaccess').to_s %>
+    ARGS="$ARGS APP_LOG_CONTENT_ACCESS=<%= p('dynatrace.applogaccess') %>"
+<% else %>
+    <% if p('dynatrace.applogaccess').blank? %>
+        #do nothing
+        :
+    <% else %>
+        installLog "Invalid Value for option 'applogaccess' expected 0/1, but got '<%= p('dynatrace.applogaccess') %>'"
+        exit 1
+     <% end %>
+<% end %>
+
+<% if ['0','1'].include? p('dynatrace.infraonly').to_s %>
+    ARGS="$ARGS INFRA_ONLY=<%= p('dynatrace.infraonly') %>"
+<% else %>
+    <% if p('dynatrace.infraonly').blank? %>
+        #do nothing
+        :
+    <% else %>
+        installLog "Invalid Value for option 'infraonly' expected 0/1, but got '<%= p('dynatrace.infraonly') %>'"
+        exit 1
+     <% end %>
+<% end %>
 
 # set downloadurl to fallback if not given
 if [[ "$DOWNLOADURL" == "" ]]; then

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -8,7 +8,7 @@ export ENV_ID="<%= p("dynatrace.environmentid") %>"
 export API_TOKEN="<%= p("dynatrace.apitoken") %>"
 export API_URL="<%= p("dynatrace.apiurl") %>"
 export SSL_MODE="<%= p("dynatrace.sslmode") %>"
-#export APP_LOG_CONTENT_ACCESS="<%= p("dynatrace.applogaccess") %>"
+export APP_LOG_CONTENT_ACCESS="<%= p("dynatrace.applogaccess") %>"
 
 export TMPDIR="/var/vcap/data/dt_tmp"
 
@@ -32,10 +32,6 @@ if [[ "$PROXY" != "" ]]; then
     export https_proxy="$PROXY"
     export http_proxy="$PROXY"
 fi
-
-#if [[ "$APP_LOG_CONTENT_ACCESS" != "" ]]; then
-#    ARGS="$ARGS APP_LOG_CONTENT_ACCESS=$APP_LOG_CONTENT_ACCESS"
-#fi
 
 <% if ['0','1'].include? p('dynatrace.applogaccess').to_s %>
     ARGS="$ARGS APP_LOG_CONTENT_ACCESS=<%= p('dynatrace.applogaccess') %>"


### PR DESCRIPTION
Dynatrace allows to switch the monitoring mode between “Full-Stack” and “Cloud-Infrastructure”. This is done by passing the “INFRA_ONLY” parameter to the installer, as described here:

https://answers.dynatrace.com/questions/191041/how-to-enable-only-infrastructure-monitoring-and-d.html

In this PR we try to make this Feature available for the bosh-oneagent-release.

Other changes:
* Added Error-handling to the parameter applogaccess
