### PR TITLE
Import service.sh library from scripts directory

### DIFF
--- a/jobs/dynatrace-oneagent/templates/start-oneagent.sh.erb
+++ b/jobs/dynatrace-oneagent/templates/start-oneagent.sh.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source ./service.sh
+source "$(dirname "${BASH_SOURCE[0]}")/service.sh"
 
 RUN_DIR="/var/vcap/sys/run/dynatrace-oneagent"
 

--- a/jobs/dynatrace-oneagent/templates/stop-oneagent.sh.erb
+++ b/jobs/dynatrace-oneagent/templates/stop-oneagent.sh.erb
@@ -2,7 +2,7 @@
 
 INSTALL_DIR="/var/vcap/data/dynatrace/oneagent"
 
-source ./service.sh
+source "$(dirname "${BASH_SOURCE[0]}")/service.sh"
 
 if [[ ! -d "${INSTALL_DIR}" ]]; then
     echo "Dynatrace OneAgent already uninstalled"


### PR DESCRIPTION
Referencing `./service.sh` fails if the current directory is not `bin`, which is the case when monit executes operations.

The fix is to use the directory of the script being executed.