### PR TITLE
Improve logging messages when download fails

### DIFF
--- a/jobs/dynatrace-oneagent-windows/templates/start.ps1
+++ b/jobs/dynatrace-oneagent-windows/templates/start.ps1
@@ -127,6 +127,8 @@ function downloadAgent($src, $dest) {
 			Invoke-WebRequest $downloadUrl -Outfile $installerPath
 			Break
 		} Catch {
+			installLog "ERROR" "Failed to download: $($_.Exception.Message)"
+
 			$downloadErrors = $downloadErrors + 1
 			$retryTimeout = $retryTimeout + 5
 			installLog "ERROR" "Dynatrace agent download failed, retrying in $retryTimeout seconds"

--- a/jobs/dynatrace-oneagent-windows/templates/start.ps1
+++ b/jobs/dynatrace-oneagent-windows/templates/start.ps1
@@ -94,12 +94,12 @@ function removeInstallerArchive() {
 
 function removeExpandedInstaller() {
 	try {
-		installLog "INFO", "Cleaning $agentExpandPath"
+		installLog "INFO" "Cleaning $agentExpandPath"
 		if (Test-Path -Path $agentExpandPath) {
 			deleteItem $agentExpandPath
 		}
 	} catch {
-		installLog "ERROR", "Unable to remove directory: $agentExpandPath"
+		installLog "ERROR" "Unable to remove directory: $agentExpandPath"
 	}
 }
 
@@ -136,7 +136,7 @@ function downloadAgent($src, $dest) {
 	}
 
 	if ($downloadErrors -eq 3) {
-		installLog "error" "ERROR: Downloading agent installer failed!"
+		installLog "ERROR" "Downloading agent installer failed!"
 		Exit 1
 	}
 }
@@ -178,7 +178,7 @@ function setHostProps() {
 # ==================================================
 # main section
 # ==================================================
-installLog "INFO", "Installing Dynatrace OneAgent..."
+installLog "INFO" "Installing Dynatrace OneAgent..."
 CleanupAll
 
 if (!(Test-Path $tempDir)) {
@@ -218,7 +218,7 @@ installLog "INFO" "Using API URL $cfgApiUrl"
 downloadAgent $cfgDownloadUrl $installerFile
 
 try {
-	installLog "INFO", "Expanding $installerFile to $agentExpandPath..."
+	installLog "INFO" "Expanding $installerFile to $agentExpandPath..."
 	Unzip "$installerFile" "$agentExpandPath"
 } catch {
 	installLog "ERROR" "Failed to extract $installerFile to $agentExpandPath"

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -93,7 +93,7 @@ setHostTags() {
     if [[ "${HOST_TAGS}" != "" ]]; then
         local hostTagsFile="${CONFIG_DIR}/hostautotag.conf"
 
-        installLog "INFO" "Setting host tags to '${HOST_TAGS}' at ${hostTagsFile}"
+        installLog "Setting host tags to '${HOST_TAGS}' at ${hostTagsFile}"
         echo -n "${HOST_TAGS}" > "${hostTagsFile}"
     fi
 }
@@ -102,7 +102,7 @@ setHostProps() {
     if [[ "${HOST_PROPS}" != "" ]]; then
         local hostPropsFile="${CONFIG_DIR}/hostcustomproperties.conf"
 
-        installLog "INFO" "Setting host properties to '${HOST_PROPS}' at ${hostPropsFile}"
+        installLog "Setting host properties to '${HOST_PROPS}' at ${hostPropsFile}"
         echo -n "${HOST_PROPS}" > "${hostPropsFile}"
     fi
 }

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -112,9 +112,9 @@ downloadAgent() {
     local installerFile=$2
 
     if curl -h &> /dev/null ; then
-        local downloadCommand="curl -f --connect-timeout 10 $SSL_INSECURE_CURL ${downloadUrl} -o ${installerFile}"
+        local downloadCommand="curl -s -S -f --connect-timeout 10 $SSL_INSECURE_CURL ${downloadUrl} -o ${installerFile}"
     elif wget -h &> /dev/null ; then
-        local downloadCommand="wget --connect-timeout=10 $SSL_INSECURE_WGET ${downloadUrl} -O ${installerFile}"
+        local downloadCommand="wget --connect-timeout=10 -nv $SSL_INSECURE_WGET ${downloadUrl} -O ${installerFile}"
     else
         installLog "ERROR: Neither curl nor wget executable found!"
         exit 1
@@ -126,8 +126,8 @@ downloadAgent() {
         sleep $retryTimeout
 
         installLog "Downloading agent installer from ${downloadUrl}"
-        $downloadCommand
-        if [[ $? != 0 ]]; then
+        $downloadCommand 2>&1 | tee -a "${LOG_FILE}"
+        if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
             downloadErrors=$((downloadErrors+1))
             retryTimeout=$($retryTimeout+5)
 
@@ -135,6 +135,7 @@ downloadAgent() {
                 installLog "Dynatrace agent download failed, retrying in $retryTimeout seconds"
             fi
         else
+            installLog "Download was successful"
             break
         fi
     done

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -129,7 +129,7 @@ downloadAgent() {
         $downloadCommand 2>&1 | tee -a "${LOG_FILE}"
         if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
             downloadErrors=$((downloadErrors+1))
-            retryTimeout=$($retryTimeout+5)
+            retryTimeout=$((retryTimeout+5))
 
             if [[ $downloadErrors -lt 3 ]]; then
                 installLog "Dynatrace agent download failed, retrying in $retryTimeout seconds"


### PR DESCRIPTION
The add-on isn't storing any output from the download attempts, so in case of failures we wouldn't be aware of the cause.

This PR adds logging of the result for download instructions in both Linux and Windows releases. It also includes minor fixes to some existing log entries that are being printed incorrectly.