### PR TITLE
Log release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ All releases since 0.3.6 upwards are packaged via bosh2. This means you can't up
 Since v2.0 of the Cloud Foundry Ops Manager, bosh2 is the default and is simply called with 'bosh'. If you use a version prior to that, bosh2 should be available besides the default bosh1. You can call it with the 'bosh2' command.
 Replace the commands above respectively
 
+Releases since v1.0.5 also require BOSH Director v263 or greater.
+
 ## License
 
 Licensed under the MIT License. See the [LICENSE](https://github.com/dynatrace-innovationlab/bosh-oneagent-release/blob/master/LICENSE) file for details.

--- a/jobs/dynatrace-oneagent-windows/templates/drain.ps1
+++ b/jobs/dynatrace-oneagent-windows/templates/drain.ps1
@@ -16,6 +16,8 @@ function drainLog($level, $content) {
 	Write-Output $line | Out-File -Encoding utf8 -Append $drainLogFile
 }
 
+drainLog "INFO" "Dynatrace BOSH Add-on version <%= spec.release.version %>"
+
 If ($cfgDownloadUrl -ne "" -and $cfgDownloadUrl -match "^https:\/\/") {
 	$splitOptions = [System.StringSplitOptions]::RemoveEmptyEntries
 	$customDownloadUrl = $cfgDownloadUrl.Split("//", $splitOptions)[1].Split("/", $splitOptions)[0]

--- a/jobs/dynatrace-oneagent-windows/templates/pre-start.ps1.erb
+++ b/jobs/dynatrace-oneagent-windows/templates/pre-start.ps1.erb
@@ -7,6 +7,8 @@ $cfgDownloadUrl = "<%= properties.dynatrace.downloadurl %>"
 $addDomains = @()
 $addDomains = "dynatrace.com", "dynatrace-managed.com"
 
+Write-Output "Dynatrace BOSH Add-on version <%= spec.release.version %>"
+
 If ($cfgDownloadUrl -ne "") {
 	$splitOptions = [System.StringSplitOptions]::RemoveEmptyEntries
 	$customDownloadUrl = $cfgDownloadUrl.Split("//", $splitOptions)[1].Split("/", $splitOptions)[0]

--- a/jobs/dynatrace-oneagent-windows/templates/start.ps1
+++ b/jobs/dynatrace-oneagent-windows/templates/start.ps1
@@ -176,7 +176,10 @@ function setHostProps() {
 # ==================================================
 # main section
 # ==================================================
-installLog "INFO", "Installing Dynatrace OneAgent..."
+
+installLog "INFO" "Dynatrace BOSH Add-on version <%= spec.release.version %>"
+
+installLog "INFO" "Installing Dynatrace OneAgent..."
 CleanupAll
 
 if (!(Test-Path $tempDir)) {

--- a/jobs/dynatrace-oneagent/templates/drain.erb
+++ b/jobs/dynatrace-oneagent/templates/drain.erb
@@ -8,6 +8,8 @@ installLog() {
     echo "$1" >> "${DRAIN_LOG}"
 }
 
+installLog "Dynatrace BOSH Add-on version <%= spec.release.version %>"
+
 installLog "Uninstalling the OneAgent..."
 
 agentDir="${INSTALL_DIR}"

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -25,6 +25,8 @@ installLog() {
     echo "$1" | tee -a "${LOG_FILE}"
 }
 
+installLog "Dynatrace BOSH Add-on version <%= spec.release.version %>"
+
 if ! mkdir -p "${RUN_DIR}" "${LOG_DIR}" "${CONFIG_DIR}"; then
     installLog "ERROR: Creating directories ${RUN_DIR}, ${LOG_DIR} and ${CONFIG_DIR} failed!"
     exit 1


### PR DESCRIPTION
To ease support, this PR adds log entries with the add-on version using the template variable `spec.release.version`.

Such variable is available since [BOSH Director v263](https://bosh.cloudfoundry.org/releases/github.com/cloudfoundry/bosh?version=263) so a note has been also added to the README.