### PR TITLE
Store release version as a custom property

### DIFF
--- a/jobs/dynatrace-oneagent-windows/templates/start.ps1
+++ b/jobs/dynatrace-oneagent-windows/templates/start.ps1
@@ -14,7 +14,7 @@ $cfgApiUrl = "<%= properties.dynatrace.apiurl %>"
 $cfgSslMode = "<%= properties.dynatrace.sslmode %>"
 $cfgHostGroup = "<%= properties.dynatrace.hostgroup %>"
 $cfgHostTags = "<%= properties.dynatrace.hosttags %>"
-$cfgHostProps = "<%= properties.dynatrace.hostprops %>"
+$cfgHostProps = "<%= properties.dynatrace.hostprops %> BOSH_RELEASE_VERSION=<%= spec.release.version %>"
 $cfgInfraOnly = "<%= properties.dynatrace.infraonly %>"
 
 $oneagentwatchdogProcessName = "oneagentwatchdog"
@@ -167,12 +167,10 @@ function setHostTags() {
 }
 
 function setHostProps() {
-	if ($cfgHostProps -ne "") {
-		$hostPropsFile = "${configDir}\hostcustomproperties.conf"
+	$hostPropsFile = "${configDir}\hostcustomproperties.conf"
 
-		installLog "INFO" "Setting host properties to '$cfgHostProps' at $hostPropsFile"
-		Set-Content -Path $hostPropsFile -Value $cfgHostProps
-	}
+	installLog "INFO" "Setting host properties to '$cfgHostProps' at $hostPropsFile"
+	Set-Content -Path $hostPropsFile -Value $cfgHostProps
 }
 
 # ==================================================

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -11,7 +11,7 @@ export SSL_MODE="<%= p("dynatrace.sslmode") %>"
 export APP_LOG_CONTENT_ACCESS="<%= p("dynatrace.applogaccess") %>"
 export HOST_GROUP="<%= p("dynatrace.hostgroup") %>"
 export HOST_TAGS="<%= p("dynatrace.hosttags") %>"
-export HOST_PROPS="<%= p("dynatrace.hostprops") %>"
+export HOST_PROPS="<%= p("dynatrace.hostprops") %> BOSH_RELEASE_VERSION=<%= spec.release.version %>"
 export INFRA_ONLY="<%= p("dynatrace.infraonly") %>"
 
 export TMPDIR="/var/vcap/data/dt_tmp"
@@ -101,12 +101,10 @@ setHostTags() {
 }
 
 setHostProps() {
-    if [[ "${HOST_PROPS}" != "" ]]; then
-        local hostPropsFile="${CONFIG_DIR}/hostcustomproperties.conf"
+    local hostPropsFile="${CONFIG_DIR}/hostcustomproperties.conf"
 
-        installLog "Setting host properties to '${HOST_PROPS}' at ${hostPropsFile}"
-        echo -n "${HOST_PROPS}" > "${hostPropsFile}"
-    fi
+    installLog "Setting host properties to '${HOST_PROPS}' at ${hostPropsFile}"
+    echo -n "${HOST_PROPS}" > "${hostPropsFile}"
 }
 
 downloadAgent() {

--- a/spec/jobs/dynatrace-oneagent_spec.rb
+++ b/spec/jobs/dynatrace-oneagent_spec.rb
@@ -40,7 +40,7 @@ describe 'dynatrace release' do
           expect(script).to match('^export APP_LOG_CONTENT_ACCESS="1"$')
           expect(script).to match('^export HOST_GROUP=""$')
           expect(script).to match('^export HOST_TAGS=""$')
-          expect(script).to match('^export HOST_PROPS=""$')
+          expect(script).to match('^export HOST_PROPS=" BOSH_RELEASE_VERSION=123"$')
           expect(script).to match('^export INFRA_ONLY="0"$')
         end
       end


### PR DESCRIPTION
This PR stores the BOSH Release version as the custom property `BOSH_RELEASE_VERSION`.