### PR TITLE
Update custom property key for add-on version

### DIFF
--- a/jobs/dynatrace-oneagent-windows/templates/start.ps1
+++ b/jobs/dynatrace-oneagent-windows/templates/start.ps1
@@ -14,7 +14,7 @@ $cfgApiUrl = "<%= properties.dynatrace.apiurl %>"
 $cfgSslMode = "<%= properties.dynatrace.sslmode %>"
 $cfgHostGroup = "<%= properties.dynatrace.hostgroup %>"
 $cfgHostTags = "<%= properties.dynatrace.hosttags %>"
-$cfgHostProps = "<%= properties.dynatrace.hostprops %> BOSH_RELEASE_VERSION=<%= spec.release.version %>"
+$cfgHostProps = "<%= properties.dynatrace.hostprops %> BOSHReleaseVersion=<%= spec.release.version %>"
 $cfgInfraOnly = "<%= properties.dynatrace.infraonly %>"
 
 $oneagentwatchdogProcessName = "oneagentwatchdog"

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -11,7 +11,7 @@ export SSL_MODE="<%= p("dynatrace.sslmode") %>"
 export APP_LOG_CONTENT_ACCESS="<%= p("dynatrace.applogaccess") %>"
 export HOST_GROUP="<%= p("dynatrace.hostgroup") %>"
 export HOST_TAGS="<%= p("dynatrace.hosttags") %>"
-export HOST_PROPS="<%= p("dynatrace.hostprops") %> BOSH_RELEASE_VERSION=<%= spec.release.version %>"
+export HOST_PROPS="<%= p("dynatrace.hostprops") %> BOSHReleaseVersion=<%= spec.release.version %>"
 export INFRA_ONLY="<%= p("dynatrace.infraonly") %>"
 
 export TMPDIR="/var/vcap/data/dt_tmp"

--- a/spec/jobs/dynatrace-oneagent_spec.rb
+++ b/spec/jobs/dynatrace-oneagent_spec.rb
@@ -40,7 +40,7 @@ describe 'dynatrace release' do
           expect(script).to match('^export APP_LOG_CONTENT_ACCESS="1"$')
           expect(script).to match('^export HOST_GROUP=""$')
           expect(script).to match('^export HOST_TAGS=""$')
-          expect(script).to match('^export HOST_PROPS=" BOSH_RELEASE_VERSION=123"$')
+          expect(script).to match('^export HOST_PROPS=" BOSHReleaseVersion=123"$')
           expect(script).to match('^export INFRA_ONLY="0"$')
         end
       end


### PR DESCRIPTION
Changing the custom property key from `BOSH_RELEASE_VERSION` to `BOSHReleaseVersion` for consistency with the Dynatrace CloudFoundry dashboard.