### PR TITLE
Support running the Rspec tests in both Ubuntu 14.04 and 16.04 containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.dev_builds
+dev_releases
+*.tgz

--- a/Dockerfile-DeploymentApiMock
+++ b/Dockerfile-DeploymentApiMock
@@ -1,0 +1,10 @@
+# Using Go 1.12 to support go get for the module with a specific version. Update to release version once it's available.
+FROM golang:1.12beta2
+ENV GO111MODULE on
+RUN go get -d github.com/Dynatrace/deployment-api-mock@v0.1.0
+RUN CGO_ENABLED=0 GOOS=linux go install -v github.com/Dynatrace/deployment-api-mock
+
+FROM alpine:latest
+WORKDIR /workspace/
+COPY --from=0 /go/bin/deployment-api-mock .
+ENTRYPOINT ./deployment-api-mock

--- a/Dockerfile-Test-Ubuntu14.04
+++ b/Dockerfile-Test-Ubuntu14.04
@@ -1,0 +1,26 @@
+FROM ubuntu:14.04
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get -y install curl ca-certificates gnupg2 build-essential dos2unix --no-install-recommends && \
+    apt-get clean
+
+# Instructions from https://rvm.io/rvm/install
+RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN curl -sSL https://get.rvm.io | bash -s stable
+RUN /bin/bash -c '. /etc/profile.d/rvm.sh && rvm install 2.3 && gem install bundler'
+
+WORKDIR /tmp/workspace
+
+# Install Ruby dependencies
+COPY Gemfile ./
+RUN /bin/bash -c '. /etc/profile.d/rvm.sh && bundle'
+
+# Copy scripts code and tests.
+COPY jobs/ ./jobs/
+COPY spec/ ./spec/
+
+# Traverse through the directory and force line endings to Unix.
+RUN find jobs/ spec/jobs/ -type f -name '*' | xargs dos2unix
+
+ENTRYPOINT /bin/bash -c '. /etc/profile.d/rvm.sh && bundle exec rspec --format documentation'

--- a/Dockerfile-Test-Ubuntu16.04
+++ b/Dockerfile-Test-Ubuntu16.04
@@ -1,0 +1,26 @@
+FROM ubuntu:16.04
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get -y install ruby dos2unix curl --no-install-recommends && \
+    apt-get clean && \
+    gem install bundler
+
+WORKDIR /tmp/workspace
+
+# Install Ruby dependencies
+COPY Gemfile ./
+RUN bundle
+
+# Copy scripts code and tests.
+COPY jobs/ ./jobs/
+COPY spec/ ./spec/
+
+# Traverse through the directory and force line endings to Unix.
+RUN find jobs/ spec/jobs/ -type f -name '*' | xargs dos2unix
+
+# Override /bin/systemctl - the Docker container doesn't start under Systemd, so calls to systemctl fail.
+# We don't really need systemctl, so this is enough as a workaround.
+RUN echo "#!/bin/sh\nexit 0" > /bin/systemctl
+
+ENTRYPOINT bundle exec rspec --format documentation

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,38 +1,21 @@
 # Integration Tests for Dynatrace OneAgent BOSH Release
 
-**WARNING**: The current state of the test setup requires root permissions.
-We recommend to only run them in a seperate VM, which does not host anything else.
+There are scripts available that run the tests under Docker containers trying to simulate Ubuntu 14.04 and Ubuntu 16.04 environments.
 
 ## Requirements
-* Ubuntu 14/Ubuntu 16
-* Ruby 2.1+
-
-## Bootstrap test environment
-* Clone this repository to $repodir
-
-```bash
-curl -sSL https://get.rvm.io | bash -s stable
-source ~/.rvm/scripts/rvm
-rvm install 2.1
-gem install bundler
-cd $repodir
-bundle
-```
+* Docker
+* docker-compose
 
 ## Run tests
-* Set needed environment variables:
+
+Linux:
+
 ```bash
-export DT_TENANT=sometenantid
-export DT_API_TOKEN=someapitoken
-```
-* (optional) If not running against a live.dynatrace.com tenant, set API URL as well:
-```bash
-export DT_API_URL=http://your.api.url
+$ scripts/integration-tests.sh
 ```
 
-* Actually run the tests:
-```bash
-cd $repodir
-sudo -s
-rspec
+Windows:
+
+```batch
+> scripts\integration-tests.bat
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  deployment-api-mock:
+    build:
+      dockerfile: ./Dockerfile-DeploymentApiMock
+      context: ./
+    ports:
+      - "8080"
+    networks:
+      - testnet
+networks:
+  testnet:

--- a/scripts/integration-tests.bat
+++ b/scripts/integration-tests.bat
@@ -1,0 +1,39 @@
+@ECHO OFF
+
+PUSHD "%~dp0\.."
+
+SET TAG_UBUNTU_1404=bosh-oneagent-release-test-ubuntu-14.04
+SET TAG_UBUNTU_1604=bosh-oneagent-release-test-ubuntu-16.04
+
+ECHO Starting up services...
+docker-compose up --detach --build || GOTO :error
+
+ECHO Building Ubuntu 14.04 image for tests...
+docker build --tag %TAG_UBUNTU_1404% --file Dockerfile-Test-Ubuntu14.04 . || GOTO :error
+
+ECHO Building Ubuntu 16.04 image for tests...
+docker build --tag %TAG_UBUNTU_1604% --file Dockerfile-Test-Ubuntu16.04 . || GOTO :error
+
+ECHO Running tests for Ubuntu 14.04...
+docker run --rm --env "DEPLOYMENT_MOCK_URL=http://deployment-api-mock:8080" --network "bosh-oneagent-release_testnet" ^
+           %TAG_UBUNTU_1404% || GOTO :error
+
+ECHO Running tests for Ubuntu 16.04...
+docker run --rm --env "DEPLOYMENT_MOCK_URL=http://deployment-api-mock:8080" --network "bosh-oneagent-release_testnet" ^
+           %TAG_UBUNTU_1604% || GOTO :error
+
+ECHO Shutting down services...
+docker-compose down
+
+POPD
+
+GOTO :EOF
+
+:error
+ECHO Shutting down services...
+docker-compose down
+
+POPD
+
+ECHO Task failed
+EXIT /b %errorlevel%

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+cd "$(dirname "$0")/.."
+
+TAG_UBUNTU_1404=bosh-oneagent-release-test-ubuntu-14.04
+TAG_UBUNTU_1604=bosh-oneagent-release-test-ubuntu-16.04
+
+echo Starting up services...
+if ! docker-compose up --detach --build ; then
+    echo Task failed
+    exit 1
+fi
+
+function fail {
+    echo Shutting down services...
+    docker-compose down
+
+    echo Task failed
+    exit 1
+}
+
+echo Building Ubuntu 14.04 image for tests...
+docker build --tag $TAG_UBUNTU_1404 --file Dockerfile-Test-Ubuntu14.04 . || fail
+
+echo Building Ubuntu 16.04 image for tests...
+docker build --tag $TAG_UBUNTU_1604 --file Dockerfile-Test-Ubuntu16.04 . || fail
+
+echo Running tests for Ubuntu 14.04...
+docker run --rm --env "DEPLOYMENT_MOCK_URL=http://deployment-api-mock:8080" --network "bosh-oneagent-release_testnet" $TAG_UBUNTU_1404 || fail
+
+echo Running tests for Ubuntu 16.04...
+docker run --rm --env "DEPLOYMENT_MOCK_URL=http://deployment-api-mock:8080" --network "bosh-oneagent-release_testnet" $TAG_UBUNTU_1604 || fail
+
+echo Shutting down services...
+docker-compose down


### PR DESCRIPTION
We currently need to have real agent credentials to run the tests for the project. They also force us to use VMs.

This PR takes advantage of the Deployment API Mock, which return dummy agent installers, to be able to run the Rspec tests inside containers.

Including also `scripts/integration_tests.sh` and `scripts/integration_tests.bat` as helper Bash and Batch scripts, respectively, to run the tests in both Ubuntu 14.04 and 16.04 containers.