### PR TITLE
Fixed faulty downloadurl behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+linux_templates = $(wildcard jobs/dynatrace-oneagent/templates/*.erb)
+windows_templates = $(wildcard jobs/dynatrace-oneagent-windows/templates/*.erb)
+
+.PHONY: lint
+lint:
+	shellcheck -x jobs/dynatrace-oneagent/templates/*.erb
+
+.PHONY: test
+test:
+	integration/linux/run-tests.sh
+
+dev-bosh-oneagent-release.tgz: $(linux_templates) $(windows_templates)
+	bosh create-release --force --tarball=dev-bosh-oneagent-release.tgz
+
+dev-release: dev-bosh-oneagent-release.tgz
+
+.PHONY: dump-runtime-config
+dump-runtime-config:
+	bosh config --type runtime --name dynatrace > dt-runtime-config.yaml
+
+.PHONY: update-config
+update-config:
+	bosh update-config --type runtime --name dynatrace dt-runtime-config.yaml
+
+.PHONY: clean
+clean:
+	rm dt-runtime-config.yaml dev-bosh-oneagent-release.tgz

--- a/jobs/dynatrace-oneagent-windows/spec
+++ b/jobs/dynatrace-oneagent-windows/spec
@@ -13,8 +13,10 @@ packages: []
 properties:
   dynatrace.environmentid:
     description: 'Dynatrace environment ID'
+    default: ''
   dynatrace.apitoken:
     description: 'API token'
+    default: ''
   dynatrace.apiurl:
     description: 'URL to Dynatrace API endpoint'
     default: ''

--- a/jobs/dynatrace-oneagent-windows/templates/pre-start.ps1.erb
+++ b/jobs/dynatrace-oneagent-windows/templates/pre-start.ps1.erb
@@ -96,7 +96,7 @@ function setupSslAcceptAll {
     [System.Net.ServicePointManager]::CertificatePolicy = $trustAll
 }
 
-function downloadAgent() {
+function downloadAgent($downloadUrl) {
     $userAgent = "bosh/<%= spec.release.version %>"
     $retryTimeout = 0
     $downloadErrors = 0
@@ -111,13 +111,19 @@ function downloadAgent() {
         Start-Sleep -s $retryTimeout
 
         Try {
-            installLog "INFO" "Downloading Dynatrace agent from $cfgDownloadUrl to $installerFile"
-            
-            if($cfgProxy -ne "") {
-                installLog "INFO" "Proxy settings found, setting the proxy for the OneAgent download to $cfgProxy"
-                Invoke-WebRequest $cfgDownloadUrl -Outfile $installerFile -UserAgent $userAgent -Proxy $cfgProxy -Header $authHeader
-            } else {
-                Invoke-WebRequest $cfgDownloadUrl -Outfile $installerFile -UserAgent $userAgent -Header $authHeader
+            installLog "INFO" "Downloading Dynatrace agent from $downloadUrl to $installerFile"
+
+            if ($cfgProxy -eq "" -And $cfgDownloadUrl -eq "") {
+                Invoke-WebRequest $downloadUrl -Outfile $installerFile -UserAgent $userAgent -Header $authHeader
+            }
+            elseif ($cfgProxy -eq "" -And $cfgDownloadUrl -ne "") {
+                Invoke-WebRequest $downloadUrl -Outfile $installerFile -UserAgent $userAgent
+            }
+            elseif ($cfgProxy -ne "" -And $cfgDownloadUrl -eq "") {
+                Invoke-WebRequest $downloadUrl -Outfile $installerFile -UserAgent $userAgent -Header $authHeader -Proxy $cfgProxy
+            }
+            elseif ($cfgProxy -ne "" -And $cfgDownloadUrl -ne "") {
+                Invoke-WebRequest $downloadUrl -Outfile $installerFile -UserAgent $userAgent -Proxy $cfgProxy
             }
 
             Break
@@ -200,7 +206,9 @@ if ($cfgDownloadUrl.length -eq 0){
         $cfgApiUrl = "http://{0}.live.dynatrace.com/api" -f $cfgEnvironmentId
     }
 
-    $cfgDownloadUrl = "{0}/v1/deployment/installer/agent/windows/default/latest" -f $cfgApiUrl
+    $downloadUrl = "{0}/v1/deployment/installer/agent/windows/default/latest" -f $cfgApiUrl
+} else {
+    $downloadUrl = $cfgDownloadUrl
 }
 
 updateTrustedSites
@@ -209,7 +217,7 @@ updateTrustedSites
 # do we really want to log these?
 installLog "INFO" "Using API URL $cfgApiUrl"
 
-downloadAgent
+downloadAgent $downloadUrl
 
 #run the installer
 try {

--- a/jobs/dynatrace-oneagent/spec
+++ b/jobs/dynatrace-oneagent/spec
@@ -14,8 +14,10 @@ packages: []
 properties:
   dynatrace.environmentid:
     description: 'Dynatrace environment ID'
+    default: ''
   dynatrace.apitoken:
     description: 'API token'
+    default: ''
   dynatrace.apiurl:
     description: 'URL to Dynatrace API endpoint'
     default: ''

--- a/jobs/dynatrace-oneagent/templates/drain.erb
+++ b/jobs/dynatrace-oneagent/templates/drain.erb
@@ -23,6 +23,8 @@ fi
 if [[ -f "${agentDir}/agent/uninstall.sh" ]]; then
     installLog "Found uninstall script to run..."
     sh "${agentDir}/agent/uninstall.sh" >> "${DRAIN_LOG}" 2>&1
+    # Disabling the warning since it's better readable that way
+    # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then
         installLog "ERROR: Uninstall script failed!"
         echo "1"

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -2,20 +2,35 @@
 
 export PATH="/var/vcap/packages/dynatrace-oneagent:$PATH"
 
-export DOWNLOADURL="<%= p("dynatrace.downloadurl") %>"
-export PROXY="<%= p("dynatrace.proxy") %>"
-export ENV_ID="<%= p("dynatrace.environmentid") %>"
-export API_TOKEN="<%= p("dynatrace.apitoken") %>"
-export API_URL="<%= p("dynatrace.apiurl") %>"
-export SSL_MODE="<%= p("dynatrace.sslmode") %>"
-export APP_LOG_CONTENT_ACCESS="<%= p("dynatrace.applogaccess") %>"
-export HOST_GROUP="<%= p("dynatrace.hostgroup") %>"
-export HOST_TAGS="<%= p("dynatrace.hosttags") %>"
-export HOST_PROPS="<%= p("dynatrace.hostprops") %> BOSHReleaseVersion=<%= spec.release.version %>"
-export INFRA_ONLY="<%= p("dynatrace.infraonly") %>"
-export VALIDATEDOWNLOAD="<%= p("dynatrace.validatedownload") %>"
-export INSTALLERARGS="<%= p("dynatrace.installerargs") %>"
-export INJECTION_RULES="<%= p("dynatrace.injectionrules") %>"
+# Disabling because shellcheck stumbles over the eruby syntax here
+# shellcheck disable=SC2140
+export CFG_DOWNLOADURL="<%= p("dynatrace.downloadurl") %>"
+# shellcheck disable=SC2140
+export CFG_PROXY="<%= p("dynatrace.proxy") %>"
+# shellcheck disable=SC2140
+export CFG_ENV_ID="<%= p("dynatrace.environmentid") %>"
+# shellcheck disable=SC2140
+export CFG_API_TOKEN="<%= p("dynatrace.apitoken") %>"
+# shellcheck disable=SC2140
+export CFG_API_URL="<%= p("dynatrace.apiurl") %>"
+# shellcheck disable=SC2140
+export CFG_SSL_MODE="<%= p("dynatrace.sslmode") %>"
+# shellcheck disable=SC2140
+export CFG_APP_LOG_CONTENT_ACCESS="<%= p("dynatrace.applogaccess") %>"
+# shellcheck disable=SC2140
+export CFG_HOST_GROUP="<%= p("dynatrace.hostgroup") %>"
+# shellcheck disable=SC2140
+export CFG_HOST_TAGS="<%= p("dynatrace.hosttags") %>"
+# shellcheck disable=SC2140
+export CFG_HOST_PROPS="<%= p("dynatrace.hostprops") %> BOSHReleaseVersion=<%= spec.release.version %>"
+# shellcheck disable=SC2140
+export CFG_INFRA_ONLY="<%= p("dynatrace.infraonly") %>"
+# shellcheck disable=SC2140
+export CFG_VALIDATEDOWNLOAD="<%= p("dynatrace.validatedownload") %>"
+# shellcheck disable=SC2140
+export CFG_INSTALLERARGS="<%= p("dynatrace.installerargs") %>"
+# shellcheck disable=SC2140
+export CFG_INJECTION_RULES="<%= p("dynatrace.injectionrules") %>"
 
 export TMPDIR="/var/vcap/data/dt_tmp"
 
@@ -35,74 +50,76 @@ if ! mkdir -p "${RUN_DIR}" "${LOG_DIR}" "${CONFIG_DIR}"; then
     exit 1
 fi
 
-if [[ -n "$INJECTION_RULES" ]]; then
+if [[ -n "$CFG_INJECTION_RULES" ]]; then
     installLog "INFO: Config for DT_INJECTION_RULES found, setting global environment variable"
 
-    systemctl set-environment DT_INJECTION_RULES="$INJECTION_RULES"
-    echo "DefaultEnvironment=DT_INJECTION_RULES=$INJECTION_RULES" >> /etc/systemd/system.conf
+    systemctl set-environment DT_INJECTION_RULES="$CFG_INJECTION_RULES"
+    echo "DefaultEnvironment=DT_INJECTION_RULES=$CFG_INJECTION_RULES" >> /etc/systemd/system.conf
     systemctl daemon-reload
 fi
 
-if [[ -z "$INSTALLERARGS" ]]; then
-    if [[ "$PROXY" != "" ]]; then
-        installLog "Setting proxy to ${PROXY}"
-        INSTALLERARGS="$INSTALLERARGS PROXY=$PROXY"
-        export https_proxy="$PROXY"
-        export http_proxy="$PROXY"
+if [[ -z "$CFG_INSTALLERARGS" ]]; then
+    if [[ "$CFG_PROXY" != "" ]]; then
+        installLog "Setting proxy to ${CFG_PROXY}"
+        INSTALLERARGS="$CFG_INSTALLERARGS PROXY=$CFG_PROXY"
+        export https_proxy="$CFG_PROXY"
+        export http_proxy="$CFG_PROXY"
     fi
 
-    if [[ "$APP_LOG_CONTENT_ACCESS" == "1" ]]; then
+    if [[ "$CFG_APP_LOG_CONTENT_ACCESS" == "1" ]]; then
         installLog "Enabling log monitoring"
-        INSTALLERARGS="$INSTALLERARGS APP_LOG_CONTENT_ACCESS=$APP_LOG_CONTENT_ACCESS"
+        CFG_INSTALLERARGS="$CFG_INSTALLERARGS APP_LOG_CONTENT_ACCESS=$CFG_APP_LOG_CONTENT_ACCESS"
     fi
 
-    if [[ "$HOST_GROUP" != "" ]]; then
-        installLog "Setting host group to ${HOST_GROUP}"
-        INSTALLERARGS="$INSTALLERARGS HOST_GROUP=$HOST_GROUP"
+    if [[ "$CFG_HOST_GROUP" != "" ]]; then
+        installLog "Setting host group to ${CFG_HOST_GROUP}"
+        INSTALLERARGS="$CFG_INSTALLERARGS HOST_GROUP=$CFG_HOST_GROUP"
     fi
 
-    if [[ "$INFRA_ONLY" == "1" ]]; then
+    if [[ "$CFG_INFRA_ONLY" == "1" ]]; then
         installLog "Enabling Infra-Only mode"
-        INSTALLERARGS="$INSTALLERARGS INFRA_ONLY=$INFRA_ONLY"
+        INSTALLERARGS="$CFG_INSTALLERARGS INFRA_ONLY=$CFG_INFRA_ONLY"
     fi
 else
-    if [[ "$INSTALLERARGS" =~ "APP_LOG_CONTENT_ACCESS" ]]; then
-        INSTALLERARGS="$INSTALLERARGS"
+    if [[ "$CFG_INSTALLERARGS" =~ "APP_LOG_CONTENT_ACCESS" ]]; then
+        INSTALLERARGS="$CFG_INSTALLERARGS"
     else
         installLog "Enabling log monitoring"
-        INSTALLERARGS="$INSTALLERARGS APP_LOG_CONTENT_ACCESS=1"
+        INSTALLERARGS="$CFG_INSTALLERARGS APP_LOG_CONTENT_ACCESS=1"
     fi
 fi
 
 # set downloadurl to fallback if not given
-if [[ "$DOWNLOADURL" == "" ]]; then
-    if [[ "$ENV_ID" == "" ]] || [[ "$API_TOKEN" == "" ]]; then
+if [[ -z "$CFG_DOWNLOADURL" ]]; then
+    if [[ "$CFG_ENV_ID" == "" ]] || [[ "$CFG_API_TOKEN" == "" ]]; then
         installLog "Invalid configuration:"
         installLog "Please set environment ID and API token for Dynatrace OneAgent."
         exit 1
     fi
-    if [[ "$API_URL" == "" ]]; then
-        API_URL="https://$ENV_ID.live.dynatrace.com/api"
+
+    if [[ -z "$CFG_API_URL" ]]; then
+        CFG_API_URL="https://$CFG_ENV_ID.live.dynatrace.com/api"
     fi
-    DOWNLOADURL="$API_URL/v1/deployment/installer/agent/unix/default/latest"
+
+    DOWNLOADURL="$CFG_API_URL/v1/deployment/installer/agent/unix/default/latest"
+else
+    DOWNLOADURL="$CFG_DOWNLOADURL"
 fi
 
 # set validatedownload to false (fallback) if not set
-if [[ "$VALIDATEDOWNLOAD" == "" ]]; then
+if [[ "$CFG_VALIDATEDOWNLOAD" == "" ]]; then
     installLog "Download validation is off by default"
-    VALIDATEDOWNLOAD=false
-fi
-
-if [[ "$VALIDATEDOWNLOAD" == true ]]; then
+    CFG_VALIDATEDOWNLOAD=false
+elif [[ "$CFG_VALIDATEDOWNLOAD" == true ]]; then
     installLog "Enabling download validation"
-    VALIDATEDOWNLOAD=true
+    CFG_VALIDATEDOWNLOAD=true
 else
-    VALIDATEDOWNLOAD=false
+    CFG_VALIDATEDOWNLOAD=false
 fi
 
 SSL_INSECURE_CURL=""
 SSL_INSECURE_WGET=""
-if [[ "$SSL_MODE" == "all" ]]; then
+if [[ "$CFG_SSL_MODE" == "all" ]]; then
     installLog "accepting all ssl certificates for agent download"
     SSL_INSECURE_CURL="--insecure"
     SSL_INSECURE_WGET="--no-check-certificate"
@@ -125,36 +142,41 @@ setWatchdogPid() {
 }
 
 setHostTags() {
-    if [[ "${HOST_TAGS}" != "" ]]; then
+    if [[ "${CFG_HOST_TAGS}" != "" ]]; then
         local hostTagsFile="${CONFIG_DIR}/hostautotag.conf"
 
-        installLog "Setting host tags to '${HOST_TAGS}' at ${hostTagsFile}"
-        echo -n "${HOST_TAGS}" > "${hostTagsFile}"
+        installLog "Setting host tags to '${CFG_HOST_TAGS}' at ${hostTagsFile}"
+        echo -n "${CFG_HOST_TAGS}" > "${hostTagsFile}"
     fi
 }
 
 setHostProps() {
     local hostPropsFile="${CONFIG_DIR}/hostcustomproperties.conf"
 
-    installLog "Setting host properties to '${HOST_PROPS}' at ${hostPropsFile}"
-    echo -n "${HOST_PROPS}" > "${hostPropsFile}"
+    installLog "Setting host properties to '${CFG_HOST_PROPS}' at ${hostPropsFile}"
+    echo -n "${CFG_HOST_PROPS}" > "${hostPropsFile}"
 }
 
 validateAgent() {
-    installLog "Validating the downloaded file..." 
+    installLog "Validating the downloaded file..."
     if [[ -e $1 ]]; then
         rm -f dt-root.cert.pem
         wget https://ca.dynatrace.com/dt-root.cert.pem
 
+        # Disabling the warning since it's better readable this way
+        # shellcheck disable=SC2181
         if [[ $? != 0 ]] || ! openssl -h &> /dev/null ; then
             installLog "WARNING: could not validate integrity of the download"
             return 2
         fi
 
+        # shellcheck disable=SC2086
         ( echo 'Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="--SIGNED-INSTALLER"'; \
           echo ; echo ; echo '----SIGNED-INSTALLER' ; cat $1 ) \
         | openssl cms -verify -CAfile dt-root.cert.pem > /dev/null
 
+       # Disabling the warning since it's better readable this way
+       # shellcheck disable=SC2181
        if [[ $? != 0 ]]; then
            installLog "ERROR: Validation failed! An error occurred while trying to download the Dynatrace agent"
            return 1
@@ -188,7 +210,11 @@ downloadAgent() {
         sleep $retryTimeout
 
         installLog "Downloading agent installer from ${downloadUrl}"
-        $downloadCommand --header "Authorization: Api-Token $API_TOKEN" 2>&1 | tee -a "${LOG_FILE}"
+        if [[ -z "$CFG_DOWNLOADURL" ]]; then
+           $downloadCommand --header "Authorization: Api-Token $CFG_API_TOKEN" 2>&1 | tee -a "${LOG_FILE}"
+        else
+           $downloadCommand  2>&1 | tee -a "${LOG_FILE}"
+        fi
 
         if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
             downloadErrors=$((downloadErrors+1))
@@ -199,7 +225,9 @@ downloadAgent() {
             fi
         else
             if [[ $validateDownload == true ]] && [[ -e $2 ]]; then
-                validateAgent $2
+                validateAgent "$2"
+                # Disabling the warning since it's better readable that way
+                # shellcheck disable=SC2181
                 if [[ $? -ne 0 ]]; then
                     installLog "Download validation failed!"
                 else
@@ -236,7 +264,10 @@ runInstaller() {
         pgrep -f Dynatrace-OneAgent > /dev/null
         local installerFound=$?
         if [[ $installerFound -eq 1 ]]; then
-            sh "${INSTALLER_FILE}" ${INSTALLERARGS} INSTALL_PATH="$INSTALL_DIR" 2>&1 | tee -a "$LOG_FILE"
+            # Disabling quoting check here, because $INSTALLERARGS would be
+            # handed over weirdly when quoted
+            # shellcheck disable=SC2086
+            sh "${INSTALLER_FILE}" $INSTALLERARGS INSTALL_PATH="$INSTALL_DIR" 2>&1 | tee -a "$LOG_FILE"
             if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
                 installLog "ERROR: Installation failed"
                 exit 1
@@ -267,7 +298,7 @@ setHostTags
 setHostProps
 
 INSTALLER_FILE="$TMPDIR/Dynatrace-OneAgent-Linux.sh"
-downloadAgent "$DOWNLOADURL" "$INSTALLER_FILE" "$VALIDATEDOWNLOAD"
+downloadAgent "$DOWNLOADURL" "$INSTALLER_FILE" "$CFG_VALIDATEDOWNLOAD"
 
 runInstaller
 

--- a/jobs/dynatrace-oneagent/templates/start-oneagent.sh.erb
+++ b/jobs/dynatrace-oneagent/templates/start-oneagent.sh.erb
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# shellcheck source=jobs/dynatrace-oneagent/templates/service.sh
 source "$(dirname "${BASH_SOURCE[0]}")/service.sh"
 
 RUN_DIR="/var/vcap/sys/run/dynatrace-oneagent"

--- a/jobs/dynatrace-oneagent/templates/stop-oneagent.sh.erb
+++ b/jobs/dynatrace-oneagent/templates/stop-oneagent.sh.erb
@@ -2,6 +2,7 @@
 
 INSTALL_DIR="/var/vcap/data/dynatrace/oneagent"
 
+# shellcheck source=jobs/dynatrace-oneagent/templates/service.sh
 source "$(dirname "${BASH_SOURCE[0]}")/service.sh"
 
 if [[ ! -d "${INSTALL_DIR}" ]]; then

--- a/runtime-config-dynatrace.yml
+++ b/runtime-config-dynatrace.yml
@@ -1,70 +1,52 @@
 releases:
 - name: dynatrace-oneagent
-  version: 1.1.0
+  version: 1.3.3
 
 addons:
 - name: dynatrace-oneagent-addon
   jobs:
   - name: dynatrace-oneagent
     release: dynatrace-oneagent
+    properties:
+      dynatrace:
+        environmentid: <environmentId>
+        apitoken: <paas-token> # sorry it's confusing :(
+        ###
+        # optional properties below
+        ###
+        # Replace with your Dynatrace Managed URL, including the environment ID.
+        # An example URL might look like the following
+        apiurl: https://{your-managed-cluster.com}/e/{environmentid}/api
+        # Set to 'all' if you want to accept all self-signed SSL certificates.
+        sslmode: all
+        # Specify a direct download URL for Dynatrace OneAgent.
+        # If this propery is set, BOSH will download OneAgent from this location.
+        downloadurl: https://direct-download-url-for-agent
+        # Specify the proxy to be used for communication.
+        proxy: https://your-proxy-url
+        # Specify in which hostgroup the VMs in this deployments belong
+        hostgroup: example_hostgroup
+        # Define host tags for the VMs in this deployment
+        hosttags: landscape=production team=my_team
+        # Define custom properties for the VMs in this deployment
+        hostprops: Department=Acceptance Stage=Sprint
+        # Enable cloud infrastructure monitoring mode.
+        # Set this to 1 to activate it
+        infraonly: 0
+        # Enable validation of the download via certificate
+        # Set this to true to active it
+        validatedownload: false
+        # Hand over any installer argument
+        # Use either this OR the hostgroup, hosttags, infraonly, proxy properties.
+        # Usage of 'installerargs' will overwrite the others!
+        installerargs: HOST_GROUP=example_hostgroup INFRA_ONLY=0
   include:
     deployments:
       - name-of-your-deployment
     stemcell:
       - os: ubuntu-trusty
   exclude:
-    # for bosh versions upwards of v262.8.0 you can use:
     lifecycle: errand
-    # for older bosh versions, you need to exclude errands/smoke-tests manually.
-    # Uncomment the "jobs" block for that and add additional jobs as needed:
-    #jobs:
-    #- {name: smoke-tests, release: cf}
-    #- {name: push-apps-manager, release: push-apps-manager-release}
-    #- {name: deploy-notifications, release: notifications}
-    #- {name: deploy-notifications-ui, release: notifications-ui}
-    #- {name: push-pivotal-account, release: pivotal-account}
-    #- {name: deploy-autoscaling, release: cf-autoscaling}
-    #- {name: register-broker, release: cf-autoscaling}
-    #- {name: nfsbrokerpush, release: nfs-volume}
-    #- {name: bootstrap, release: cf-mysql}
-    #- {name: rejoin-unsafe, release: cf-mysql}
-    #- {name: broker-registrar, release: cf-mysql}
-    #- {name: deregister-and-purge-instances, release: cf-mysql}
-    #- {name: smoke-tests, release: cf-mysql}
-    #- {name: install-hwc-buildpack, release: hwc-buildpack}
-  properties:
-    dynatrace:
-      environmentid: <environmentId>
-      apitoken: <paas-token> # sorry it's confusing :(
-      ###
-      # optional properties below
-      ###
-      # Replace with your Dynatrace Managed URL, including the environment ID.
-      # An example URL might look like the following
-      apiurl: https://{your-managed-cluster.com}/e/{environmentid}/api
-      # Set to 'all' if you want to accept all self-signed SSL certificates.
-      sslmode: all
-      # Specify a direct download URL for Dynatrace OneAgent.
-      # If this propery is set, BOSH will download OneAgent from this location.
-      downloadurl: https://direct-download-url-for-agent
-      # Specify the proxy to be used for communication.
-      proxy: https://your-proxy-url
-      # Specify in which hostgroup the VMs in this deployments belong
-      hostgroup: example_hostgroup
-      # Define host tags for the VMs in this deployment
-      hosttags: landscape=production team=my_team
-      # Define custom properties for the VMs in this deployment
-      hostprops: Department=Acceptance Stage=Sprint
-      # Enable cloud infrastructure monitoring mode.
-      # Set this to 1 to activate it
-      infraonly: 0
-      # Enable validation of the download via certificate
-      # Set this to true to active it
-      validatedownload: false
-      # Hand over any installer argument
-      # Use either this OR the hostgroup, hosttags, infraonly, proxy properties.
-      # Usage of 'installerargs' will overwrite the others!
-      installerargs: HOST_GROUP=example_hostgroup INFRA_ONLY=0
 
 
 # optional: extra addon configuration for Windows cells
@@ -72,15 +54,15 @@ addons:
   jobs:
   - name: dynatrace-oneagent-windows
     release: dynatrace-oneagent
-  include:
+    properties:
+      dynatrace:
+        environmentid: <environmentId>
+        apitoken: <paas-token>  # sorry it's confusing :(
+        # All of the optional properties for the Linux addon shown above (for example, apiurl, hostgroup) can also be used here.  include:
     deployments:
       - name-of-your-deployment
     stemcell:
       - os: windows2012R2
   exclude:
     lifecycle: errand
-  properties:
-    dynatrace:
-      environmentid: <environmentId>
-      apitoken: <paas-token>  # sorry it's confusing :(
-      # All of the optional properties for the Linux addon shown above (for example, apiurl, hostgroup) can also be used here.
+

--- a/spec/jobs/release_linux_spec.rb
+++ b/spec/jobs/release_linux_spec.rb
@@ -31,17 +31,17 @@ describe 'dynatrace release', :linux do
         it 'render' do
           script = template.render(manifest, spec: release_version)
 
-          expect(script).to match('^export DOWNLOADURL=""$')
-          expect(script).to match('^export PROXY=""$')
-          expect(script).to match('^export ENV_ID="environmentid"$')
-          expect(script).to match('^export API_TOKEN="apitoken"$')
-          expect(script).to match('^export API_URL=""$')
-          expect(script).to match('^export SSL_MODE=""$')
-          expect(script).to match('^export APP_LOG_CONTENT_ACCESS="1"$')
-          expect(script).to match('^export HOST_GROUP=""$')
-          expect(script).to match('^export HOST_TAGS=""$')
-          expect(script).to match('^export HOST_PROPS=" BOSHReleaseVersion=123"$')
-          expect(script).to match('^export INFRA_ONLY="0"$')
+          expect(script).to match('^export CFG_DOWNLOADURL=""$')
+          expect(script).to match('^export CFG_PROXY=""$')
+          expect(script).to match('^export CFG_ENV_ID="environmentid"$')
+          expect(script).to match('^export CFG_API_TOKEN="apitoken"$')
+          expect(script).to match('^export CFG_API_URL=""$')
+          expect(script).to match('^export CFG_SSL_MODE=""$')
+          expect(script).to match('^export CFG_APP_LOG_CONTENT_ACCESS="1"$')
+          expect(script).to match('^export CFG_HOST_GROUP=""$')
+          expect(script).to match('^export CFG_HOST_TAGS=""$')
+          expect(script).to match('^export CFG_HOST_PROPS=" BOSHReleaseVersion=123"$')
+          expect(script).to match('^export CFG_INFRA_ONLY="0"$')
         end
       end
 


### PR DESCRIPTION
added basic Makefile
updated makefile
added empty default for envid and apitoken, so they are not needed when only supplying downloadurl
added windows templates to makefile
fixed downloadurl handling in windows job
added clean step to makefile
updated runtime-config structure
enabled checking for external sources with shellcheck
disabled some shellcheck warnings intentionally
bumped release version in example config